### PR TITLE
feat: add funcs related to unicode conversion

### DIFF
--- a/gurmukhiutils/unicode.py
+++ b/gurmukhiutils/unicode.py
@@ -1,3 +1,4 @@
+import re
 from typing import Literal, Match
 
 UNICODE_STANDARDS = Literal["Unicode Consortium", "Sant Lipi"]
@@ -28,8 +29,6 @@ def unicode(
         >>> unicode("gurU")
         'ਗੁਰੂ'
     """
-
-    import re
 
     # AnmolLipi/GurbaniAkhar & GurbaniLipi by Kulbir S. Thind, MD
     common_ascii_to_unicode_map = {
@@ -210,7 +209,6 @@ def unicode(
     string = unicode_normalize(string)
 
     if unicode_standard == "Unicode Consortium":
-        import re
 
         # Map Sant Lipi to Unicode Consortium
         for key, value in sant_lipi_to_unicode_compliant_map.items():
@@ -269,8 +267,6 @@ def sort_diacritics(string: str) -> str:
         >>> sort_diacritics("\u0a41\u0a4b") == "\u0a4b\u0a41"  # ੁੋ vs  ੋੁ
         True
     """
-
-    import re
 
     """
     Nukta is essential to form a new base letter and must be ordered first.

--- a/gurmukhiutils/unicode.py
+++ b/gurmukhiutils/unicode.py
@@ -179,7 +179,7 @@ def unicode(
 
     # Move ASCII sihari before mapping to unicode
     ASCII_BASE_LETTERS = "a-zA-Z\\|^&Îîï"
-    ASCII_SIHARI_PATTERN = r"(i)([" + ASCII_BASE_LETTERS + "])"
+    ASCII_SIHARI_PATTERN = rf"(i)([{ASCII_BASE_LETTERS}])"
     string = re.sub(ASCII_SIHARI_PATTERN, r"\2\1", string)
 
     # Replace any ASCII with Unicode Gurmukhi
@@ -295,18 +295,18 @@ def sort_diacritics(string: str) -> str:
     GENERATED_MARKS = "".join(
         BASE_LETTER_MODIFIERS + VOWEL_ORDER + REMAINING_MODIFIER_ORDER
     )
-    MARK_PATTERN = "([" + GENERATED_MARKS + "]*)"
+    MARK_PATTERN = f"([{GENERATED_MARKS}]*)"
 
     VIRAMA = "੍"
     BELOW_BASE_LETTERS = "ਹਰਵਟਤਨਚ"
-    BELOW_BASE_PATTERN = "(" + VIRAMA + "[" + BELOW_BASE_LETTERS + "])?"
+    BELOW_BASE_PATTERN = f"({VIRAMA}[{BELOW_BASE_LETTERS}])?"
 
     """
     The following regex will capture all sequential diacritics containing at most one subjoined letter.
         >>> print(REGEX_MATCH_PATTERN)
         '([਼ੵਿੇੈੋੌੁੂਾੀਁੱਂੰਃ]*)(੍[ਹਰਵਟਤਨਚ])?([਼ੵਿੇੈੋੌੁੂਾੀਁੱਂੰਃ]*)'
     """
-    REGEX_MATCH_PATTERN = MARK_PATTERN + BELOW_BASE_PATTERN + MARK_PATTERN
+    REGEX_MATCH_PATTERN = f"{MARK_PATTERN}{BELOW_BASE_PATTERN}{MARK_PATTERN}"
 
     """
     This generates a string of the order in which all diacritics should appear.

--- a/gurmukhiutils/unicode.py
+++ b/gurmukhiutils/unicode.py
@@ -11,6 +11,11 @@ def unicode(
     """
     Converts any ascii gurmukhi characters and sanitizes to unicode gurmukhi.
 
+    Note:
+        Converting yayya (ਯ) variants with an open-top using the Unicode Consortium standard is considered destructive. This function will substitute the original with it's shirorekha/top-line equivalent.
+
+        Many fonts and text shaping engines fail to render half-yayya (੍ਯ) correctly. Regardless of the standard used, it is recommended to use the Sant Lipi font mentioned below.
+
     Args:
         string: The string to affect.
 
@@ -160,37 +165,16 @@ def unicode(
 
     # OpenGurbaniAkhar by Sarabveer Singh (GurbaniNow)
     SANT_LIPI_MAP = {
-        "Î": "\ueeec",  # replace capital i-circumflex letter, half-yayya
-        "੍ਯ": "\ueeec",  # replace unicode half-yayya
-        "î": "\ueeee",  # i-circumflex letter, open-top half-yayya
-        "ï": "\ueeef",  # i-diaeresis letter, open-top full yayya
-        "\u2080": "\uee80",  # missing subscript 0 (₀)
-        "\u2081": "\uee81",  # subscript 1 (₁) number
-        "\u2082": "\uee82",  # subscript 2 (₂) number
-        "\u2083": "\uee83",  # subscript 3 (₃) number
-        "\u2084": "\uee84",  # subscript 4 (₄) number
-        "\u2085": "\uee85",  # subscript 5 (₅) number
-        "\u2086": "\uee86",  # subscript 6 (₆) number
-        "\u2087": "\uee87",  # missing subscript 7 (₇)
-        "\u2088": "\uee88",  # subscript 8 (₈) number
-        "\u2089": "\uee89",  # missing subscript 9 (₉)
+        "Î": "꠳ਯ",  # replace capital i-circumflex letter with indic one-sixteenth + yayya = half-yayya
+        "੍ਯ": "꠳ਯ",  # replace unicode half-yayya with same as above
+        "ï": "꠴ਯ",  # replace i-diaeresis letter with indic one-eight + yayya = open-top full yayya
+        "î": "꠵ਯ",  # replace i-circumflex letter with indic three-sixtenths + yayya = open-top half-yayya
     }
 
     SANT_LIPI_TO_STANDARD_MAP = {
-        "\ueeec": "੍ਯ",
-        "\ueeee": "੍ਯ",
-        "\ueeef": "ਯ",
-        # The Shabad OS Database as of 2022-06-27 only has these occur before a white-space character:
-        "\uee80": "₀",
-        "\uee81": "₁",
-        "\uee82": "₂",
-        "\uee83": "₃",
-        "\uee84": "₄",
-        "\uee85": "₅",
-        "\uee86": "₆",
-        "\uee87": "₇",
-        "\uee88": "₈",
-        "\uee89": "₉",
+        "꠳ਯ": "੍ਯ",
+        "꠴ਯ": "ਯ",
+        "꠵ਯ": "੍ਯ",
     }
 
     # Move ASCII sihari before mapping to unicode
@@ -213,17 +197,6 @@ def unicode(
         # Map Sant Lipi to Unicode Consortium
         for key, value in SANT_LIPI_TO_STANDARD_MAP.items():
             string = string.replace(key, value)
-
-        """
-        Fix occurences of half-yayya + diacritic(s)
-
-        This seems to be a major pitfall of the Unicode standard.
-
-        Looks as though using a subjoined character for what is actually a base letter, there is no way to properly add accents / vowels to either the half-y or the letter preceding it.
-
-        Recommendation is to use Sant Lipi standard + font in the mean time.
-        """
-        string = re.sub("(੍ਯ)([਼੍ੵਿੇੈੋੌੁੂਾੀਁੱਂੰਃ]+)", r"ਯ\2", string)
 
     return string
 

--- a/gurmukhiutils/unicode.py
+++ b/gurmukhiutils/unicode.py
@@ -12,7 +12,7 @@ def unicode(
     Converts any ascii gurmukhi characters and sanitizes to unicode gurmukhi.
 
     Note:
-        Converting yayya (ਯ) variants with an open-top using the Unicode Consortium standard is considered destructive. This function will substitute the original with it's shirorekha/top-line equivalent.
+        Converting yayya (ਯ) variants with an open top using the Unicode Consortium standard is considered destructive. This function will substitute the original with it's shirorekha/top-line equivalent.
 
         Many fonts and text shaping engines fail to render half-yayya (੍ਯ) correctly. Regardless of the standard used, it is recommended to use the Sant Lipi font mentioned below.
 
@@ -35,98 +35,139 @@ def unicode(
         'ਗੁਰੂ'
     """
 
+    # Font mapping
     # AnmolLipi/GurbaniAkhar & GurbaniLipi by Kulbir S. Thind, MD
-    ASCII_TO_UNICODE_MAP = {
-        "a": "ੳ",
-        "b": "ਬ",
-        "c": "ਚ",
-        "d": "ਦ",
-        "e": "ੲ",
-        "f": "ਡ",
-        "g": "ਗ",
-        "h": "ਹ",
-        "i": "ਿ",
-        "j": "ਜ",
-        "k": "ਕ",
-        "l": "ਲ",
-        "m": "ਮ",
-        "n": "ਨ",
-        "o": "ੋ",
-        "p": "ਪ",
-        "q": "ਤ",
-        "r": "ਰ",
-        "s": "ਸ",
-        "t": "ਟ",
-        "u": "ੁ",
-        "v": "ਵ",
-        "w": "ਾ",
-        "x": "ਣ",
-        "y": "ੇ",
-        "z": "ਜ਼",
-        "A": "ਅ",
-        "B": "ਭ",
-        "C": "ਛ",
-        "D": "ਧ",
-        "E": "ਓ",
-        "F": "ਢ",
-        "G": "ਘ",
-        "H": "੍ਹ",
-        "I": "ੀ",
-        "J": "ਝ",
-        "K": "ਖ",
-        "L": "ਲ਼",
-        "M": "ੰ",
-        "N": "ਂ",
-        "O": "ੌ",
-        "P": "ਫ",
-        "Q": "ਥ",
-        "R": "੍ਰ",
-        "S": "ਸ਼",
-        "T": "ਠ",
-        "U": "ੂ",
-        "V": "ੜ",
-        "W": "ਾਂ",
-        "X": "ਯ",
-        "Y": "ੈ",
-        "Z": "ਗ਼",
-        "0": "੦",
-        "1": "੧",
-        "2": "੨",
-        "3": "੩",
-        "4": "੪",
-        "5": "੫",
-        "6": "੬",
-        "7": "੭",
-        "8": "੮",
-        "9": "੯",
-        "[": "।",
-        "]": "॥",
-        "\\": "ਞ",
-        "|": "ਙ",
-        "`": "ੱ",
-        "~": "ੱ",
-        "@": "ੑ",
-        "^": "ਖ਼",
-        "&": "ਫ਼",
-        "†": "੍ਟ",  # dagger symbol
-        "ü": "ੁ",  # u-diaeresis letter
-        "®": "੍ਰ",  # registered symbol
-        "\u00b4": "ੵ",  # acute accent (´)
-        "\u00a8": "ੂ",  # diaeresis accent (¨)
-        "µ": "ੰ",  # mu letter
-        "æ": "਼",
-        "\u00a1": "ੴ",  # inverted exclamation (¡)
-        "ƒ": "ਨੂੰ",  # florin symbol
-        "œ": "੍ਤ",
-        "Í": "੍ਵ",  # capital i-acute letter
-        "Î": "੍ਯ",  # capital i-circumflex letter
-        "Ï": "ੵ",  # capital i-diaeresis letter
-        "Ò": "॥",  # capital o-grave letter
-        "Ú": "ਃ",  # capital u-acute letter
-        "\u02c6": "ਂ",  # circumflex accent (ˆ)
-        "\u02dc": "੍ਨ",  # small tilde (˜)
+    # OpenGurbaniAkhar by Sarabveer Singh (GurbaniNow)
+    ASCII_TO_SL_TRANSLATION = {
+        ord("a"): "ੳ",
+        ord("b"): "ਬ",
+        ord("c"): "ਚ",
+        ord("d"): "ਦ",
+        ord("e"): "ੲ",
+        ord("f"): "ਡ",
+        ord("g"): "ਗ",
+        ord("h"): "ਹ",
+        ord("i"): "ਿ",
+        ord("j"): "ਜ",
+        ord("k"): "ਕ",
+        ord("l"): "ਲ",
+        ord("m"): "ਮ",
+        ord("n"): "ਨ",
+        ord("o"): "ੋ",
+        ord("p"): "ਪ",
+        ord("q"): "ਤ",
+        ord("r"): "ਰ",
+        ord("s"): "ਸ",
+        ord("t"): "ਟ",
+        ord("u"): "ੁ",
+        ord("v"): "ਵ",
+        ord("w"): "ਾ",
+        ord("x"): "ਣ",
+        ord("y"): "ੇ",
+        ord("z"): "ਜ਼",
+        ord("A"): "ਅ",
+        ord("B"): "ਭ",
+        ord("C"): "ਛ",
+        ord("D"): "ਧ",
+        ord("E"): "ਓ",
+        ord("F"): "ਢ",
+        ord("G"): "ਘ",
+        ord("H"): "੍ਹ",
+        ord("I"): "ੀ",
+        ord("J"): "ਝ",
+        ord("K"): "ਖ",
+        ord("L"): "ਲ਼",
+        ord("M"): "ੰ",
+        ord("N"): "ਂ",
+        ord("O"): "ੌ",
+        ord("P"): "ਫ",
+        ord("Q"): "ਥ",
+        ord("R"): "੍ਰ",
+        ord("S"): "ਸ਼",
+        ord("T"): "ਠ",
+        ord("U"): "ੂ",
+        ord("V"): "ੜ",
+        ord("W"): "ਾਂ",
+        ord("X"): "ਯ",
+        ord("Y"): "ੈ",
+        ord("Z"): "ਗ਼",
+        ord("0"): "੦",
+        ord("1"): "੧",
+        ord("2"): "੨",
+        ord("3"): "੩",
+        ord("4"): "੪",
+        ord("5"): "੫",
+        ord("6"): "੬",
+        ord("7"): "੭",
+        ord("8"): "੮",
+        ord("9"): "੯",
+        ord("["): "।",
+        ord("]"): "॥",
+        ord("\\"): "ਞ",
+        ord("|"): "ਙ",
+        ord("`"): "ੱ",
+        ord("~"): "ੱ",
+        ord("@"): "ੑ",
+        ord("^"): "ਖ਼",
+        ord("&"): "ਫ਼",
+        ord("†"): "੍ਟ",  # dagger symbol
+        ord("ü"): "ੁ",  # u-diaeresis letter
+        ord("®"): "੍ਰ",  # registered symbol
+        ord("\u00b4"): "ੵ",  # acute accent (´)
+        ord("\u00a8"): "ੂ",  # diaeresis accent (¨)
+        ord("µ"): "ੰ",  # mu letter
+        ord("æ"): "਼",
+        ord("\u00a1"): "ੴ",  # inverted exclamation (¡)
+        ord("ƒ"): "ਨੂੰ",  # florin symbol
+        ord("œ"): "੍ਤ",
+        ord("Í"): "੍ਵ",  # capital i-acute letter
+        ord("Î"): "੍ਯ",  # capital i-circumflex letter
+        ord("Ï"): "ੵ",  # capital i-diaeresis letter
+        ord("Ò"): "॥",  # capital o-grave letter
+        ord("Ú"): "ਃ",  # capital u-acute letter
+        ord("\u02c6"): "ਂ",  # circumflex accent (ˆ)
+        ord("\u02dc"): "੍ਨ",  # small tilde (˜)
         #
         #
+        # AnmolLipi/GurbaniAkhar mappings:
+        ord("§"): "੍ਹੂ",  # section symbol
+        ord("¤"): "ੱ",  # currency symbol
+        #
+        #
+        # GurbaniLipi mappings:
+        ord("ç"): "੍ਚ",  # c-cedilla letter
+        #
+        #
+        # AnmolLipi/GurbaniAkhar overriding GurbaniLipi mapping:
+        ord("Ç"): "☬",  # khanda instead of california state symbol
+        #
+        #
+        # Miscellaneous:
+        ord("\u201a"): "❁",  # single low-9 quotation (‚) mark
+        #
+        #
+        # Nullify
+        # Either the 2nd portion of ੴ or a symbol of USA:
+        ord("Æ"): None,
+        ord("Ø"): None,  # This is a topline / shirorekha (शिरोरेखा) extender
+        ord("ÿ"): None,  # This is the author Kulbir S Thind's stamp
+        ord("Œ"): None,  # Box drawing left flower
+        ord("‰"): None,  # Box drawing right flower
+        ord("Ó"): None,  # Box drawing top flower
+        ord("Ô"): None,  # Box drawing bottom flower
+        #
+        #
+        # Open Gurbani Akhar
+        # translate capital i-circumflex letter to indic one-sixteenth + yayya:
+        ord("Î"): "꠳ਯ",  # half-yayya
+        # translate i-diaeresis letter to indic one-eight + yayya:
+        ord("ï"): "꠴ਯ",  # open-top yayya
+        # translate i-circumflex letter to indic three-sixtenths + yayya:
+        ord("î"): "꠵ਯ",  # open-top half-yayya
+    }
+
+    # Ordered as such to supporth both font input methods
+    ASCII_TO_SL_REPLACEMENTS = {
         "<>": "ੴ",  # AnmolLipi/GurbaniAkhar variant
         "<": "ੴ",  # GurbaniLipi variant
         ">": "☬",  # GurbaniLipi variant
@@ -134,44 +175,15 @@ def unicode(
         "Åå": "ੴ",  # AnmolLipi/GurbaniAkhar variant
         "Å": "ੴ",  # GurbaniLipi variant
         "å": "ੴ",  # GurbaniLipi variant
-        #
-        #
-        # AnmolLipi/GurbaniAkhar mappings:
-        "§": "੍ਹੂ",  # section symbol
-        "¤": "ੱ",  # currency symbol
-        #
-        #
-        # GurbaniLipi mappings:
-        "ç": "੍ਚ",  # c-cedilla letter
-        #
-        #
-        # AnmolLipi/GurbaniAkhar overriding GurbaniLipi mapping:
-        "Ç": "☬",  # khanda instead of california state symbol
-        #
-        #
-        # Miscellaneous:
-        "\u201a": "❁",  # single low-9 quotation (‚) mark
-        #
-        #
-        # Nullify
-        "Æ": "",  # This is either the 2nd portion of ੴ or a symbol of USA. The ੴ renders correctly according to rules above.
-        "Ø": "",  # This is a topline / shirorekha (शिरोरेखा) extender
-        "ÿ": "",  # This is the author Kulbir S Thind's stamp
-        "Œ": "",  # Box drawing left flower
-        "‰": "",  # Box drawing right flower
-        "Ó": "",  # Box drawing top flower
-        "Ô": "",  # Box drawing bottom flower
     }
 
-    # OpenGurbaniAkhar by Sarabveer Singh (GurbaniNow)
-    SANT_LIPI_MAP = {
-        "Î": "꠳ਯ",  # replace capital i-circumflex letter with indic one-sixteenth + yayya = half-yayya
-        "੍ਯ": "꠳ਯ",  # replace unicode half-yayya with same as above
-        "ï": "꠴ਯ",  # replace i-diaeresis letter with indic one-eight + yayya = open-top full yayya
-        "î": "꠵ਯ",  # replace i-circumflex letter with indic three-sixtenths + yayya = open-top half-yayya
+    UNICODE_TO_SL_REPLACEMENTS = {
+        "੍ਯ": "꠳ਯ",  # replace unicode half-yayya with Sant Lipi ligature (north indic one-sixteenth fraction + yayya)
     }
 
-    SANT_LIPI_TO_STANDARD_MAP = {
+    # Sant Lipi to Unicode Consortium
+    # Avoiding a translation, in case these north indic fraction chars are used for what they're actually meant for
+    SL_TO_UNICODE_REPLACEMENTS = {
         "꠳ਯ": "੍ਯ",
         "꠴ਯ": "ਯ",
         "꠵ਯ": "੍ਯ",
@@ -182,20 +194,20 @@ def unicode(
     ASCII_SIHARI_PATTERN = rf"(i)([{ASCII_BASE_LETTERS}])"
     string = re.sub(ASCII_SIHARI_PATTERN, r"\2\1", string)
 
-    # Replace any ASCII with Unicode Gurmukhi
-    for key, value in ASCII_TO_UNICODE_MAP.items():
+    # Map any ASCII / Unicode Gurmukhi to Sant Lipi format
+    string = string.translate(ASCII_TO_SL_TRANSLATION)
+
+    for key, value in ASCII_TO_SL_REPLACEMENTS.items():
         string = string.replace(key, value)
 
-    for key, value in SANT_LIPI_MAP.items():
+    for key, value in UNICODE_TO_SL_REPLACEMENTS.items():
         string = string.replace(key, value)
 
     # Normalize Unicode
     string = unicode_normalize(string)
 
     if unicode_standard == "Unicode Consortium":
-
-        # Map Sant Lipi to Unicode Consortium
-        for key, value in SANT_LIPI_TO_STANDARD_MAP.items():
+        for key, value in SL_TO_UNICODE_REPLACEMENTS.items():
             string = string.replace(key, value)
 
     return string

--- a/gurmukhiutils/unicode.py
+++ b/gurmukhiutils/unicode.py
@@ -325,11 +325,11 @@ def sort_diacritics(string: str) -> str:
         """
         This re-arranges characters in "match" according to a custom sort order "GENERATED_MATCH_ORDER"
         """
-        if len(match := match.group()) > 1:
-            match = sorted(match, key=lambda e: GENERATED_MATCH_ORDER.index(e))
-            match = "".join(match)
+        if len(_match := match.group()) > 1:
+            _match = sorted(_match, key=lambda e: GENERATED_MATCH_ORDER.index(e))
+            _match = "".join(_match)
 
-        return match
+        return _match
 
     string = re.sub(
         REGEX_MATCH_PATTERN,

--- a/gurmukhiutils/unicode.py
+++ b/gurmukhiutils/unicode.py
@@ -384,11 +384,8 @@ def decode_unicode(string: str) -> list:
         >>> decode_unicode("To ਜੀ")
         [{'T': '0054'}, {'o': '006f'}, {' ': '0020'}, {'ਜ': '0a1c'}, {'ੀ': '0a40'}]
     """
-    list = []
-    for item in string:
-        list.append({item: format(ord(item), "04x")})
 
-    return list
+    return [{item: format(ord(item), "04x")} for item in string]
 
 
 def encode_unicode(strings: list) -> list:
@@ -408,8 +405,5 @@ def encode_unicode(strings: list) -> list:
         >>> encode_unicode(["0a1c", "0A40"])
         '['ਜ', 'ੀ']'
     """
-    encoded_list = []
-    for string in strings:
-        encoded_list.append(chr(int(string, 16)))
 
-    return encoded_list
+    return [chr(int(string, 16)) for string in strings]

--- a/gurmukhiutils/unicode.py
+++ b/gurmukhiutils/unicode.py
@@ -1,0 +1,448 @@
+from typing import Literal, Match
+
+UNICODE_STANDARDS = Literal["Unicode Consortium", "Sant Lipi"]
+
+
+def unicode(
+    string: str,
+    unicode_standard: Literal[UNICODE_STANDARDS] = "Unicode Consortium",
+) -> str:
+    """
+    Converts any ascii gurmukhi characters and sanitizes to unicode gurmukhi.
+
+    Args:
+        string: The string to affect.
+
+        unicode_standard: The mapping system to use. The default is unicode compliant and can render 99% of the Shabad OS Database. The other option "Sant Lipi" is intended for a custom unicode font bearing the same name (see: https://github.com/shabados/SantLipi). Defaults to "Unicode Consortium".
+
+    Returns:
+        A string whose Gurmukhi is normalized to a Unicode standard.
+
+    Examples:
+        >>> unicode("123")
+        '੧੨੩'
+
+        >>> unicode("<> > <")
+        'ੴ ☬ ੴ'
+
+        >>> unicode("gurU")
+        'ਗੁਰੂ'
+    """
+
+    import re
+
+    # AnmolLipi/GurbaniAkhar & GurbaniLipi by Kulbir S. Thind, MD
+    common_ascii_to_unicode_map = {
+        "a": "ੳ",
+        "b": "ਬ",
+        "c": "ਚ",
+        "d": "ਦ",
+        "e": "ੲ",
+        "f": "ਡ",
+        "g": "ਗ",
+        "h": "ਹ",
+        "i": "ਿ",
+        "j": "ਜ",
+        "k": "ਕ",
+        "l": "ਲ",
+        "m": "ਮ",
+        "n": "ਨ",
+        "o": "ੋ",
+        "p": "ਪ",
+        "q": "ਤ",
+        "r": "ਰ",
+        "s": "ਸ",
+        "t": "ਟ",
+        "u": "ੁ",
+        "v": "ਵ",
+        "w": "ਾ",
+        "x": "ਣ",
+        "y": "ੇ",
+        "z": "ਜ਼",
+        "A": "ਅ",
+        "B": "ਭ",
+        "C": "ਛ",
+        "D": "ਧ",
+        "E": "ਓ",
+        "F": "ਢ",
+        "G": "ਘ",
+        "H": "੍ਹ",
+        "I": "ੀ",
+        "J": "ਝ",
+        "K": "ਖ",
+        "L": "ਲ਼",
+        "M": "ੰ",
+        "N": "ਂ",
+        "O": "ੌ",
+        "P": "ਫ",
+        "Q": "ਥ",
+        "R": "੍ਰ",
+        "S": "ਸ਼",
+        "T": "ਠ",
+        "U": "ੂ",
+        "V": "ੜ",
+        "W": "ਾਂ",
+        "X": "ਯ",
+        "Y": "ੈ",
+        "Z": "ਗ਼",
+        "0": "੦",
+        "1": "੧",
+        "2": "੨",
+        "3": "੩",
+        "4": "੪",
+        "5": "੫",
+        "6": "੬",
+        "7": "੭",
+        "8": "੮",
+        "9": "੯",
+        "[": "।",
+        "]": "॥",
+        "\\": "ਞ",
+        "|": "ਙ",
+        "`": "ੱ",
+        "~": "ੱ",
+        "@": "ੑ",
+        "^": "ਖ਼",
+        "&": "ਫ਼",
+        "†": "੍ਟ",  # dagger symbol
+        "ü": "ੁ",  # u-diaeresis letter
+        "®": "੍ਰ",  # registered symbol
+        "\u00b4": "ੵ",  # acute accent (´)
+        "\u00a8": "ੂ",  # diaeresis accent (¨)
+        "µ": "ੰ",  # mu letter
+        "æ": "਼",
+        "\u00a1": "ੴ",  # inverted exclamation (¡)
+        "ƒ": "ਨੂੰ",  # florin symbol
+        "œ": "੍ਤ",
+        "Í": "੍ਵ",  # capital i-acute letter
+        "Î": "੍ਯ",  # capital i-circumflex letter
+        "Ï": "ੵ",  # capital i-diaeresis letter
+        "Ò": "॥",  # capital o-grave letter
+        "Ú": "ਃ",  # capital u-acute letter
+        "\u02c6": "ਂ",  # circumflex accent (ˆ)
+        "\u02dc": "੍ਨ",  # small tilde (˜)
+        #
+        #
+        "<>": "ੴ",  # AnmolLipi/GurbaniAkhar variant
+        "<": "ੴ",  # GurbaniLipi variant
+        ">": "☬",  # GurbaniLipi variant
+        #
+        "Åå": "ੴ",  # AnmolLipi/GurbaniAkhar variant
+        "Å": "ੴ",  # GurbaniLipi variant
+        "å": "ੴ",  # GurbaniLipi variant
+        #
+        #
+        # AnmolLipi/GurbaniAkhar mappings:
+        "§": "੍ਹੂ",  # section symbol
+        "¤": "ੱ",  # currency symbol
+        #
+        #
+        # GurbaniLipi mappings:
+        "ç": "੍ਚ",  # c-cedilla letter
+        #
+        #
+        # AnmolLipi/GurbaniAkhar overriding GurbaniLipi mapping:
+        "Ç": "☬",  # khanda instead of california state symbol
+        #
+        #
+        # Miscellaneous:
+        "\u201a": "❁",  # single low-9 quotation (‚) mark
+        #
+        #
+        # Nullify
+        "Æ": "",  # This is either the 2nd portion of ੴ or a symbol of USA. The ੴ renders correctly according to rules above.
+        "Ø": "",  # This is a topline / shirorekha (शिरोरेखा) extender
+        "ÿ": "",  # This is the author Kulbir S Thind's stamp
+        "Œ": "",  # Box drawing left flower
+        "‰": "",  # Box drawing right flower
+        "Ó": "",  # Box drawing top flower
+        "Ô": "",  # Box drawing bottom flower
+    }
+
+    # OpenGurbaniAkhar by Sarabveer Singh (GurbaniNow)
+    special_sant_lipi_map = {
+        "Î": "\ueeec",  # replace capital i-circumflex letter, half-yayya
+        "੍ਯ": "\ueeec",  # replace unicode half-yayya
+        "î": "\ueeee",  # i-circumflex letter, open-top half-yayya
+        "ï": "\ueeef",  # i-diaeresis letter, open-top full yayya
+        "\u2080": "\uee80",  # missing subscript 0 (₀)
+        "\u2081": "\uee81",  # subscript 1 (₁) number
+        "\u2082": "\uee82",  # subscript 2 (₂) number
+        "\u2083": "\uee83",  # subscript 3 (₃) number
+        "\u2084": "\uee84",  # subscript 4 (₄) number
+        "\u2085": "\uee85",  # subscript 5 (₅) number
+        "\u2086": "\uee86",  # subscript 6 (₆) number
+        "\u2087": "\uee87",  # missing subscript 7 (₇)
+        "\u2088": "\uee88",  # subscript 8 (₈) number
+        "\u2089": "\uee89",  # missing subscript 9 (₉)
+    }
+
+    sant_lipi_to_unicode_compliant_map = {
+        "\ueeec": "੍ਯ",
+        "\ueeee": "੍ਯ",
+        "\ueeef": "ਯ",
+        # The Shabad OS Database as of 2022-06-27 only has these occur before a white-space character:
+        "\uee80": "₀",
+        "\uee81": "₁",
+        "\uee82": "₂",
+        "\uee83": "₃",
+        "\uee84": "₄",
+        "\uee85": "₅",
+        "\uee86": "₆",
+        "\uee87": "₇",
+        "\uee88": "₈",
+        "\uee89": "₉",
+    }
+
+    # Move ASCII sihari before mapping to unicode
+    ascii_base_letters = "a-zA-Z\\|^&Îîï"
+    pattern = r"(i)([" + ascii_base_letters + "])"
+    string = re.sub(pattern, r"\2\1", string)
+
+    # Replace any ASCII with Unicode Gurmukhi
+    for key, value in common_ascii_to_unicode_map.items():
+        string = string.replace(key, value)
+
+    for key, value in special_sant_lipi_map.items():
+        string = string.replace(key, value)
+
+    # Normalize Unicode
+    string = unicode_normalize(string)
+
+    if unicode_standard == "Unicode Consortium":
+        import re
+
+        # Map Sant Lipi to Unicode Consortium
+        for key, value in sant_lipi_to_unicode_compliant_map.items():
+            string = string.replace(key, value)
+
+        """
+        Fix occurences of half-yayya + diacritic(s)
+
+        This seems to be a major pitfall of the Unicode standard.
+
+        Looks as though using a subjoined character for what is actually a base letter, there is no way to properly add accents / vowels to either the half-y or the letter preceding it.
+
+        Recommendation is to use Sant Lipi standard + font in the mean time.
+        """
+        string = re.sub("(੍ਯ)([਼੍ੵਿੇੈੋੌੁੂਾੀਁੱਂੰਃ]+)", r"ਯ\2", string)
+
+    return string
+
+
+def unicode_normalize(string: str) -> str:
+    """
+    Normalizes Gurmukhi according to Unicode Standards.
+
+    Arg:
+        string: The string to affect.
+
+    Returns:
+        Returns a string containing normalized gurmukhi.
+
+    Example:
+        >>> unicode_normalize("Hello ਜੀ")
+        'Hello ਜੀ'
+    """
+
+    string = sort_diacritics(string)
+
+    string = sanitize_unicode(string)
+
+    return string
+
+
+def sort_diacritics(string: str) -> str:
+    """
+    Orders the gurmukhi diacritics in a string according to Unicode standards.
+
+    Note:
+        Not intended for base letters with multiple subjoined letters.
+
+    Arg:
+        string: The string to affect.
+
+    Returns:
+        The same string with gurmukhi diacritics arranged in a sorted manner.
+
+    Example:
+        >>> sort_diacritics("\u0a41\u0a4b") == "\u0a4b\u0a41"  # ੁੋ vs  ੋੁ
+        True
+    """
+
+    import re
+
+    """
+    Nukta is essential to form a new base letter and must be ordered first.
+
+    Udaat, Yakash, and subjoined letters should follow.
+
+    Subjoined letters are constructed (they are not single char), so they cannot be used in the same regex group pattern. See further below for subjoined letters.
+    """
+    nukta_udaat_yakash_order_list = [
+        "਼",
+        "ੑ",
+        "ੵ",
+    ]
+
+    """
+    More generally, when a consonant or independent vowel is modified by multiple vowel signs, the sequence of the vowel signs in the underlying representation of the text should be: left, top, bottom, right.
+
+    p. 491 of The Unicode® Standard Version 14.0 – Core Specification
+
+    https://www.unicode.org/versions/Unicode14.0.0/ch12.pdf
+    """
+    vowel_order_list = [
+        "ਿ",
+        "ੇ",
+        "ੈ",
+        "ੋ",
+        "ੌ",
+        "ੁ",
+        "ੂ",
+        "ਾ",
+        "ੀ",
+    ]
+
+    """
+    The remaining diacritics are to be sorted at the end according to the following order
+    """
+    remaining_diacritic_order_list = [
+        "ਁ",
+        "ੱ",
+        "ਂ",
+        "ੰ",
+        "ਃ",
+    ]
+
+    """
+    If subjoined were single code points, we could have done a simple regex match:
+    ([  list_of_diacritics  ]+)
+
+    Since otherwise, surrounds each lookup of a subjoined letter with lookups of the rest of the diacritics (which are single char).
+
+    The patterns for the single-chars and the subjoined letters:
+    """
+    generated_single_chars = "".join(
+        nukta_udaat_yakash_order_list
+        + vowel_order_list
+        + remaining_diacritic_order_list
+    )
+    d_pattern = "([" + generated_single_chars + "]*)"
+
+    subjoin_constructor = "੍"
+    subjoin_consonants = "ਹਰਵਟਤਨਚ"
+    s_pattern = "(" + subjoin_constructor + "[" + subjoin_consonants + "])?"
+
+    """
+    The following regex will capture all sequential diacritics containing at most one subjoined letter.
+        >>> print(regex_match_pattern)
+        '([਼ੵਿੇੈੋੌੁੂਾੀਁੱਂੰਃ]*)(੍[ਹਰਵਟਤਨਚ])?([਼ੵਿੇੈੋੌੁੂਾੀਁੱਂੰਃ]*)'
+    """
+    regex_match_pattern = d_pattern + s_pattern + d_pattern
+
+    """
+    This generates a string of the order in which all diacritics should appear.
+        >>> print(generated_diacritic_order)
+        '਼ਹਰਵਟਤਨਚਿੇੈੋੌੁੂਾੀਁੱਂੰਃ'
+   """
+    generated_diacritic_order = "".join(
+        nukta_udaat_yakash_order_list
+        + [subjoin_constructor]
+        + [subjoin_consonants]
+        + vowel_order_list
+        + remaining_diacritic_order_list
+    )
+
+    def regex_sort_func(match: Match) -> str:
+        """
+        This re-arranges characters in "match" according to a custom sort order "generated_diacritic_order"
+        """
+        if len(match := match.group()) > 1:
+            match = sorted(match, key=lambda e: generated_diacritic_order.index(e))
+            match = "".join(match)
+
+        return match
+
+    string = re.sub(
+        regex_match_pattern,
+        regex_sort_func,
+        string,
+    )
+
+    return string
+
+
+def sanitize_unicode(string: str) -> str:
+    """
+    Use single char representations of constructed characters.
+    """
+
+    unicode_sanitization_map = {
+        "\u0a73\u0a4b": "\u0a13",  # ਓ
+        "\u0a05\u0a3e": "\u0a06",  # ਅ + ਾ = ਆ
+        "\u0a72\u0a3f": "\u0a07",  # ਇ
+        "\u0a72\u0a40": "\u0a08",  # ਈ
+        "\u0a73\u0a41": "\u0a09",  # ਉ
+        "\u0a73\u0a42": "\u0a0a",  # ਊ
+        "\u0a72\u0a47": "\u0a0f",  # ਏ
+        "\u0a05\u0a48": "\u0a10",  # ਐ
+        "\u0a05\u0a4c": "\u0a14",  # ਔ
+        "\u0a32\u0a3c": "\u0a33",  # ਲ਼
+        "\u0a38\u0a3c": "\u0a36",  # ਸ਼
+        "\u0a59\u0a3c": "\u0a59",  # ਖ਼
+        "\u0a5a\u0a3c": "\u0a5a",  # ਗ਼
+        "\u0a5b\u0a3c": "\u0a5b",  # ਜ਼
+        "\u0a5e\u0a3c": "\u0a5e",  # ਫ਼
+        "\u0a71\u0a02": "\u0a01",  # ਁ adak bindi (quite literally never used today or in the Shabad OS Database, only included for parity with the Unicode block)
+    }
+
+    for key, value in unicode_sanitization_map.items():
+        string = string.replace(key, value)
+
+    return string
+
+
+def decode_unicode(string: str) -> list:
+    """
+    Takes a string and returns a list of keys and values of each character and its corresponding code point.
+
+    Arg:
+        string: The string to affect.
+
+    Returns:
+        A list of each character and its corresponding code point.
+
+    Example:
+        >>> decode_unicode("To ਜੀ")
+        [{'T': '0054'}, {'o': '006f'}, {' ': '0020'}, {'ਜ': '0a1c'}, {'ੀ': '0a40'}]
+    """
+    list = []
+    for item in string:
+        list.append({item: format(ord(item), "04x")})
+
+    return list
+
+
+def encode_unicode(strings: list) -> list:
+    """
+    Takes a string and returns its corresponding unicode character.
+
+    Arg:
+        strings: The list containing any strings to encode.
+
+    Returns:
+        A list of any corresponding unicode characters.
+
+    Examples:
+        >>> encode_unicode(["0054"])
+        'T'
+
+        >>> encode_unicode(["0a1c", "0A40"])
+        '['ਜ', 'ੀ']'
+    """
+    encoded_list = []
+    for string in strings:
+        encoded_list.append(chr(int(string, 16)))
+
+    return encoded_list

--- a/gurmukhiutils/unicode.py
+++ b/gurmukhiutils/unicode.py
@@ -248,6 +248,7 @@ def sort_diacritics(string: str) -> str:
 
     Subjoined letters are constructed (they are not single char), so they cannot be used in the same regex group pattern. See further below for subjoined letters.
     """
+
     BASE_LETTER_MODIFIERS = [
         "਼",
         "ੑ",
@@ -261,6 +262,7 @@ def sort_diacritics(string: str) -> str:
 
     https://www.unicode.org/versions/Unicode14.0.0/ch12.pdf
     """
+
     VOWEL_ORDER = [
         "ਿ",
         "ੇ",
@@ -276,6 +278,7 @@ def sort_diacritics(string: str) -> str:
     """
     The remaining diacritics are to be sorted at the end according to the following order
     """
+
     REMAINING_MODIFIER_ORDER = [
         "ਁ",
         "ੱ",
@@ -292,6 +295,7 @@ def sort_diacritics(string: str) -> str:
 
     The patterns for the single-chars and the subjoined letters:
     """
+
     GENERATED_MARKS = "".join(
         BASE_LETTER_MODIFIERS + VOWEL_ORDER + REMAINING_MODIFIER_ORDER
     )
@@ -306,6 +310,7 @@ def sort_diacritics(string: str) -> str:
         >>> print(REGEX_MATCH_PATTERN)
         '([਼ੵਿੇੈੋੌੁੂਾੀਁੱਂੰਃ]*)(੍[ਹਰਵਟਤਨਚ])?([਼ੵਿੇੈੋੌੁੂਾੀਁੱਂੰਃ]*)'
     """
+
     REGEX_MATCH_PATTERN = f"{MARK_PATTERN}{BELOW_BASE_PATTERN}{MARK_PATTERN}"
 
     """
@@ -313,6 +318,7 @@ def sort_diacritics(string: str) -> str:
         >>> print(GENERATED_MATCH_ORDER)
         '਼ਹਰਵਟਤਨਚਿੇੈੋੌੁੂਾੀਁੱਂੰਃ'
    """
+
     GENERATED_MATCH_ORDER = "".join(
         BASE_LETTER_MODIFIERS
         + [VIRAMA]
@@ -325,6 +331,7 @@ def sort_diacritics(string: str) -> str:
         """
         This re-arranges characters in "match" according to a custom sort order "GENERATED_MATCH_ORDER"
         """
+
         if len(_match := match.group()) > 1:
             _match = sorted(_match, key=lambda e: GENERATED_MATCH_ORDER.index(e))
             _match = "".join(_match)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,6 +1,7 @@
-def triple_unicode(string: str) -> str:
-    from gurmukhiutils.unicode import unicode
+from gurmukhiutils.unicode import unicode
 
+
+def triple_unicode(string: str) -> str:
     return unicode(unicode(unicode(string)))
 
 
@@ -119,8 +120,6 @@ def test_unicode_ascii_conversions_subscripts():
 
 
 def test_unicode_yayya():
-    from gurmukhiutils.unicode import unicode
-
     unicode_compliant_assertions = {
         # Yayya with or without diacritics renders correctly.
         "XkIN": "ਯਕੀਂ",

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,0 +1,229 @@
+def triple_unicode(string: str) -> str:
+    from gurmukhiutils.unicode import unicode
+
+    return unicode(unicode(unicode(string)))
+
+
+def test_unicode():
+    assertions = {
+        "123": "੧੨੩",
+        "<> > <": "ੴ ☬ ੴ",
+        "gurU": "ਗੁਰੂ",
+    }
+
+    for key, value in assertions.items():
+        assert triple_unicode(key) == value
+
+
+def test_unicode_diacritics():
+    assertions = {
+        "kRwN": "ਕ੍ਰਾਂ",
+        "sÍwNiq": "ਸ੍ਵਾਂਤਿ",
+        "iBRMg": "ਭ੍ਰਿੰਗ",
+        "inR`qy": "ਨ੍ਰਿੱਤੇ",
+        "ik®`sM": "ਕ੍ਰਿੱਸੰ",
+        "AMimR`q": "ਅੰਮ੍ਰਿੱਤ",
+        "Qwin´M": "ਥਾਨੵਿੰ",
+        "kRwNq": "ਕ੍ਰਾਂਤ",
+        "k®ü`D": "ਕ੍ਰੁੱਧ",
+        "ijnHYN": "ਜਿਨ੍ਹੈਂ",
+        "hÍüYbo": "ਹ੍ਵੈੁਬੋ",
+        "nUµ": "ਨੂੰ",
+        "^u`d": "ਖ਼ੁੱਦ",
+        "PzUM": "ਫਜ਼ੂੰ",
+        "kwrmu`l-k`rwm": "ਕਾਰਮੁੱਲ-ਕੱਰਾਮ",
+        "&ru¤^y": "ਫ਼ਰੁੱਖ਼ੇ",
+        "^u¤ro": "ਖ਼ੁੱਰੋ",
+        "duoAwlY": "ਦੋੁਆਲੈ",
+        "idRV@IAw": "ਦ੍ਰਿੜੑੀਆ",
+        "kwn@ü": "ਕਾਨੑੁ",
+        "ijMn@I": "ਜਿੰਨੑੀ",
+        "El@w": "ਓਲੑਾ",
+        "swm@Y": "ਸਾਮੑੈ",
+        "kqybhuˆ": "ਕਤੇਬਹੁਂ",
+    }
+
+    for key, value in assertions.items():
+        assert triple_unicode(key) == value
+
+
+def test_unicode_sihari():
+    assertions = {
+        "BuiKAw.": "ਭੁਖਿਆ.",
+        "ਭੁਖiਆ.": "ਭੁਖਿਆ.",
+        "ਮi": "ਮਿ",
+        "ਮiਲ": "ਮਿਲ",
+        "ਮil": "ਮਲਿ",
+    }
+
+    for key, value in assertions.items():
+        assert triple_unicode(key) == value
+
+
+def test_unicode_nasalization():
+    assertions = {
+        "iQqMØI": "ਥਿਤੀੰ",  # some fonts render as ੀੰ, Sant Lipi should render  ੰ + ੀ
+        "kMØI": "ਕੀੰ",
+        "nµØIbu": "ਨੀੰਬੁ",
+        "nµØIbw": "ਨੀੰਬਾ",
+        "dyNih": "ਦੇਂਹਿ",
+    }
+
+    for key, value in assertions.items():
+        assert triple_unicode(key) == value
+
+
+def test_unicode_ascii_conversions():
+    assertions = {
+        "DR¨A": "ਧ੍ਰੂਅ",
+        "AwilsÎ": "ਆਲਿਸ੍ਯ",
+        "dwin": "ਦਾਨਿ",
+        "BIqir": "ਭੀਤਰਿ",
+        "jIau": "ਜੀਉ",
+        "[1[2[3[4[5[": "।੧।੨।੩।੪।੫।",
+        "]1]2]3]4]5]": "॥੧॥੨॥੩॥੪॥੫॥",
+        "sauifsies": "ਸਉਡਿਸਇਸ",
+        "z`rrw": "ਜ਼ੱਰਰਾ",
+        "^urSYd": "ਖ਼ੁਰਸ਼ੈਦ",
+        "luqi&": "ਲੁਤਫ਼ਿ",
+        "iekMqR": "ਇਕੰਤ੍ਰ",
+        "pRBU": "ਪ੍ਰਭੂ",
+    }
+
+    for key, value in assertions.items():
+        assert triple_unicode(key) == value
+
+
+def test_unicode_ascii_conversions_subscripts():
+    assertions = {
+        "isRis†": "ਸ੍ਰਿਸ੍ਟਿ",
+        "ik®s˜M": "ਕ੍ਰਿਸ੍ਨੰ",
+        "dsœgIrI": "ਦਸ੍ਤਗੀਰੀ",
+        "insçl": "ਨਿਸ੍ਚਲ",
+        "sÍwd": "ਸ੍ਵਾਦ",
+        "suDwK´r": "ਸੁਧਾਖੵਰ",
+        "cVH¨": "ਚੜ੍ਹੂ",
+        "cV§": "ਚੜ੍ਹੂ",
+        "im´wny": "ਮੵਿਾਨੇ",
+        "iD´wvY": "ਧੵਿਾਵੈ",
+        "idÍj": "ਦ੍ਵਿਜ",
+        "iBKÏw": "ਭਿਖੵਾ",
+        "imQÏMq": "ਮਿਥੵੰਤ",
+        "imQ´Mq": "ਮਿਥੵੰਤ",
+        "rKÏw": "ਰਖੵਾ",
+        "sMswrsÏ": "ਸੰਸਾਰਸੵ",
+    }
+
+    for key, value in assertions.items():
+        assert triple_unicode(key) == value
+
+
+def test_unicode_yayya():
+    from gurmukhiutils.unicode import unicode
+
+    unicode_compliant_assertions = {
+        # Yayya with or without diacritics renders correctly.
+        "XkIN": "ਯਕੀਂ",
+        "ipRX": "ਪ੍ਰਿਯ",
+        "hX¤wiq": "ਹਯਾੱਤਿ",
+        "hXw¤iq": "ਹਯਾੱਤਿ",
+        "hmwXUM": "ਹਮਾਯੂੰ",
+        "BXuo": "ਭਯੋੁ",
+        "XkIn": "ਯਕੀਨ",
+        # Half-Y (open-left) with no diacritics renders correctly.
+        "mDÎ": "ਮਧ੍ਯ",
+        "ilKÎqy": "ਲਿਖ੍ਯਤੇ",
+        # Half-Y with any diacritics converts the base letter to Yayya.
+        "mwnÎo": "ਮਾਨਯੋ",
+        "iBÎo": "ਭਿਯੋ",
+        "kIÎo": "ਕੀਯੋ",
+        "sÎwm": "ਸਯਾਮ",
+        "qÎwgÎo": "ਤਯਾਗਯੋ",
+        "jÎoN": "ਜਯੋਂ",
+        # Open-top Yayya doesn't exist in Unicode 14.0, converts base-letter to Yayya.
+        "nwmï": "ਨਾਮਯ",
+        "sunIïhu": "ਸੁਨੀਯਹੁ",
+        "AdyïM": "ਅਦੇਯੰ",
+        "kFïo": "ਕਢਯੋ",
+        "sïwm": "ਸਯਾਮ",
+        # Open-top Half-Y doesn't exist in Unicode 14.0.
+        # Converts to Half-Y if no diacritics,
+        # else converts to Yayya.
+        "idqïwidqî": "ਦਿਤਯਾਦਿਤ੍ਯ",
+        "qRsîo": "ਤ੍ਰਸਯੋ",
+    }
+
+    sant_lipi_assertions = {
+        # Work in progress, depends on custom font completion progress
+        "kFïo": "ਕਢ\ueeefੋ",
+        "qRsîo": "ਤ੍ਰਸ\ueeeeੋ",
+        "idqïwidqî": "ਦਿਤ\ueeefਾਦਿਤ\ueeee",
+    }
+
+    for key, value in unicode_compliant_assertions.items():
+        assert triple_unicode(key) == value
+
+    for key, value in sant_lipi_assertions.items():
+        assert (
+            unicode(unicode(unicode(key, "Sant Lipi"), "Sant Lipi"), "Sant Lipi")
+            == value
+        )
+
+
+def test_unicode_diacritic_ordering():
+    ਗੋੁਬਿੰਦ = "\u0a17\u0a4b\u0a41\u0a2c\u0a3f\u0a70\u0a26"
+    ਮਿਲੵਿੋ = "\u0a2e\u0a3f\u0a32\u0a75\u0a3f\u0a4b"
+    ਗ੍ਹਿਾਨ = "\u0a17\u0a4d\u0a39\u0a3f\u0a3e\u0a28"
+    ਸ਼੍ਰੇਣੀ = "\u0a36\u0a4d\u0a30\u0a47\u0a23\u0a40"
+    ਜੋਤੵਿੰ = "\u0a1c\u0a4b\u0a24\u0a75\u0a3f\u0a70"
+    ਬਸੵਿੰਤ = "\u0a2c\u0a38\u0a75\u0a3f\u0a70\u0a24"
+
+    assertions = {
+        "guoibMd": ਗੋੁਬਿੰਦ,
+        "gouibMd": ਗੋੁਬਿੰਦ,
+        "guoibµd": ਗੋੁਬਿੰਦ,
+        "gouibµd": ਗੋੁਬਿੰਦ,
+        "imil´o": ਮਿਲੵਿੋ,
+        "imilo´": ਮਿਲੵਿੋ,
+        "imiloÏ": ਮਿਲੵਿੋ,
+        "imilÏo": ਮਿਲੵਿੋ,
+        "\u0a2e\u0a3f\u0a32\u0a4b\u0a3f\u0a75": ਮਿਲੵਿੋ,
+        "igHwn": ਗ੍ਹਿਾਨ,
+        "igwHn": ਗ੍ਹਿਾਨ,
+        "\u0a17\u0a3f\u0a4d\u0a39\u0a3e\u0a28": ਗ੍ਹਿਾਨ,
+        "\u0a17\u0a3f\u0a3e\u0a4d\u0a39\u0a28": ਗ੍ਹਿਾਨ,
+        "\u0a17\u0a3e\u0a3f\u0a4d\u0a39\u0a28": ਗ੍ਹਿਾਨ,
+        "s®æyxI": ਸ਼੍ਰੇਣੀ,
+        "S®yxI": ਸ਼੍ਰੇਣੀ,
+        "SRyxI": ਸ਼੍ਰੇਣੀ,
+        "SyRxI": ਸ਼੍ਰੇਣੀ,
+        "sæRyxI": ਸ਼੍ਰੇਣੀ,
+        "sRæyxI": ਸ਼੍ਰੇਣੀ,
+        "syRæxI": ਸ਼੍ਰੇਣੀ,
+        "joiqÏM": ਜੋਤੵਿੰ,
+        "joiqMÏ": ਜੋਤੵਿੰ,
+        "bisÏMq": ਬਸੵਿੰਤ,
+        "bisMÏq": ਬਸੵਿੰਤ,
+    }
+
+    for key, value in assertions.items():
+        assert triple_unicode(key) == value
+
+
+def test_unicode_sanitization():
+    ਓੁ = "\u0a13\u0a41"
+    ਓੂ = "\u0a13\u0a42"
+    ਆਂ = "\u0a06\u0a02"
+
+    assertions = {
+        "aou": ਓੁ,
+        "auo": ਓੁ,
+        "aoU": ਓੂ,
+        "aUo": ਓੂ,
+        "AW": ਆਂ,
+        "ANw": ਆਂ,
+        "AwN": ਆਂ,
+    }
+
+    for key, value in assertions.items():
+        assert triple_unicode(key) == value

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -132,13 +132,13 @@ def test_unicode_yayya():
         # Half-Y (open-left) with no diacritics renders correctly.
         "mDÎ": "ਮਧ੍ਯ",
         "ilKÎqy": "ਲਿਖ੍ਯਤੇ",
-        # Half-Y with any diacritics converts the base letter to Yayya.
-        "mwnÎo": "ਮਾਨਯੋ",
-        "iBÎo": "ਭਿਯੋ",
-        "kIÎo": "ਕੀਯੋ",
-        "sÎwm": "ਸਯਾਮ",
-        "qÎwgÎo": "ਤਯਾਗਯੋ",
-        "jÎoN": "ਜਯੋਂ",
+        # Half-Y with any diacritics may render incorrectly with sub-par fonts / shaping engines
+        "mwnÎo": "ਮਾਨ੍ਯੋ",
+        "iBÎo": "ਭਿ੍ਯੋ",
+        "kIÎo": "ਕੀ੍ਯੋ",
+        "sÎwm": "ਸ੍ਯਾਮ",
+        "qÎwgÎo": "ਤ੍ਯਾਗ੍ਯੋ",
+        "jÎoN": "ਜ੍ਯੋਂ",
         # Open-top Yayya doesn't exist in Unicode 14.0, converts base-letter to Yayya.
         "nwmï": "ਨਾਮਯ",
         "sunIïhu": "ਸੁਨੀਯਹੁ",
@@ -146,21 +146,47 @@ def test_unicode_yayya():
         "kFïo": "ਕਢਯੋ",
         "sïwm": "ਸਯਾਮ",
         # Open-top Half-Y doesn't exist in Unicode 14.0.
-        # Converts to Half-Y if no diacritics,
-        # else converts to Yayya.
+        # Converts to Half-Y (may render incorrectly with sub-par fonts / shaping engines)
         "idqïwidqî": "ਦਿਤਯਾਦਿਤ੍ਯ",
-        "qRsîo": "ਤ੍ਰਸਯੋ",
+        "qRsîo": "ਤ੍ਰਸ੍ਯੋ",
     }
 
     sant_lipi_assertions = {
-        # Work in progress, depends on custom font completion progress
-        "kFïo": "ਕਢ\ueeefੋ",
-        "qRsîo": "ਤ੍ਰਸ\ueeeeੋ",
-        "idqïwidqî": "ਦਿਤ\ueeefਾਦਿਤ\ueeee",
+        # Yayya
+        "XkIN": "ਯਕੀਂ",
+        "ipRX": "ਪ੍ਰਿਯ",
+        "hX¤wiq": "ਹਯਾੱਤਿ",
+        "hXw¤iq": "ਹਯਾੱਤਿ",
+        "hmwXUM": "ਹਮਾਯੂੰ",
+        "BXuo": "ਭਯੋੁ",
+        "XkIn": "ਯਕੀਨ",
+        # Half-Y (open-left)
+        "mDÎ": "ਮਧ꠳ਯ",
+        "ilKÎqy": "ਲਿਖ꠳ਯਤੇ",
+        "mwnÎo": "ਮਾਨ꠳ਯੋ",
+        "iBÎo": "ਭਿ꠳ਯੋ",
+        "kIÎo": "ਕੀ꠳ਯੋ",
+        "sÎwm": "ਸ꠳ਯਾਮ",
+        "qÎwgÎo": "ਤ꠳ਯਾਗ꠳ਯੋ",
+        "jÎoN": "ਜ꠳ਯੋਂ",
+        # Open-top Yayya
+        "nwmï": "ਨਾਮ꠴ਯ",
+        "sunIïhu": "ਸੁਨੀ꠴ਯਹੁ",
+        "AdyïM": "ਅਦੇ꠴ਯੰ",
+        "kFïo": "ਕਢ꠴ਯੋ",
+        "sïwm": "ਸ꠴ਯਾਮ",
+        # Open-top Half-Y
+        "idqïwidqî": "ਦਿਤ꠴ਯਾਦਿਤ꠵ਯ",
+        "qRsîo": "ਤ੍ਰਸ꠵ਯੋ",
     }
 
     for key, value in unicode_compliant_assertions.items():
         assert triple_unicode(key) == value
+
+        # Sant Lipi -> Unicode Compliant -> Sant Lipi -> Unicode Compliant
+        assert (
+            unicode(unicode(unicode(unicode(key, "Sant Lipi")), "Sant Lipi")) == value
+        )
 
     for key, value in sant_lipi_assertions.items():
         assert (


### PR DESCRIPTION
<!-- Please title as if this PR were a single commit to our main branch. -->
<!-- https://docs.shabados.com/community/coding-guidelines#commit-messages -->
<!-- Also don't forget to add any reviewer(s) and link the related issue! -->

### Summary

Adds a unicode function which will convert ASCII and normalize unicode strings of Gurmukhi. Works on ASCII, Unicode, and mixed (ASCII+Unicode) Gurmukhi strings.

Adds a plethora of tests to confirm compliance with Unicode for most cases. Edge cases of half-Y and 2x non-existing top-open Y chars have also been factored in.

Has the option to convert to a special "Sant Lipi" Unicode standard. This should fix the Yayya issues with Unicode by shifting code points to the Private Use Area. This would be the recommended way of storing data for the Shabad OS Database in conjunction with the Sant Lipi font.

More testing is required with the Sant Lipi font to see if ligature rules can handle half-Y + diacritics (though PUA still seems preferable to me).

This took a very long time for me to finish, I added comments where I believe most people unaware of Unicode Gurmukhi and it's peculiarities would benefit from learning about.

### Test

- Open `Gurbani Lipi`, `Anmol Lipi`, `Gurbani Akhar`, `Open Gurbani Akhar` fonts in Glyphs app to map every possible ASCII character/ligature.
- Use regex searches on the Shabad OS Database for complex vowel arrangements.
- Read through various Unicode documents including proposals.
- Over 100 assertions for pytest including diacritical ordering, complex diacritics (e.g. triple diacritics on ਕ੍ਰਾਂ, ਸ੍ਵਾਂਤਿ, ਭ੍ਰਿੰਗ), ASCII sihari in unicode strings (`ਮiਲ -> ਮਿਲ`), best-conversions for words Unicode can't handle (e.g. `iBÎo -> ਭਿਯੋ`, uses full yayya since Unicode can't compute).

### Duration

Easily 20 hours. Somewhere between 20-30 hours of work.